### PR TITLE
Adding support for whitespaces in org alias when authenticating

### DIFF
--- a/src/services/authenticate.ts
+++ b/src/services/authenticate.ts
@@ -17,7 +17,7 @@ export async function setAuthInfo() {
             version: connection.version
         };
         //Call force:org:display to get a new token
-        const stdout = await require('child_process').execSync('sfdx force:org:display --json -u ' + defUserName).toString();
+        const stdout = require('child_process').execSync(`sfdx force:org:display --json -u \"${defUserName}\"`).toString();
         const displayResult = JSON.parse(stdout);
         authInfo.accessToken = displayResult.result.accessToken;
         //Save the token info to an environment variable for future use


### PR DESCRIPTION
I use this extension a good bit for work and found a bug where the extension would not authenticate.  I found that the problem occurs when the org alias is given a name with whitespaces.  The command to authenticate fails due it thinking that the alias has extended arguments for each whitespace.

I implemented a fix for this and tested it on my system and it works well.  I hope you implement it to the main extension! 